### PR TITLE
Installation of slaxconfig.h to includedir

### DIFF
--- a/libslax/Makefile.am
+++ b/libslax/Makefile.am
@@ -38,6 +38,7 @@ libslax_la_LIBADD = ${LIBXSLT_LIBS} -lexslt ${LIBXML_LIBS}
 
 slaxinc_HEADERS = \
      slax.h \
+     slaxconfig.h \
      slaxdata.h \
      slaxdyn.h \
      slaxversion.h \


### PR DESCRIPTION
yangc compilation depends off slaxconfig.h which is not installed by default into includedir

/opt/local/include/libslax/internal/slaxinternals.h:22:24: fatal error: slaxconfig.h: No such file or directory
 #include "slaxconfig.h"
                        ^
compilation terminated.
make[2]: **\* [yangbuiltin.lo] Error 1
