### PR TITLE
Fixed CURLOPT_SSL_VERIFYHOST bug

### DIFF
--- a/extensions/curl/ext_curl.c
+++ b/extensions/curl/ext_curl.c
@@ -822,7 +822,7 @@ extCurlDoPerform (curl_handle_t *curlp, curl_opts_t *opts)
 	/* Don't care about the signing CA */
 	curl_easy_setopt(curlp->ch_handle, CURLOPT_SSL_VERIFYPEER, 0L);
 	/* Don't care about the common name in the cert */
-	curl_easy_setopt(curlp->ch_handle, CURLOPT_SSL_VERIFYHOST, 1L);
+	curl_easy_setopt(curlp->ch_handle, CURLOPT_SSL_VERIFYHOST, 0L);
     }
 
     /*


### PR DESCRIPTION
From cURL's docs:

When CURLOPT_SSL_VERIFYHOST is 2, that certificate must indicate that the server is the server to which you meant to connect, or the connection fails. Simply put, it means it has to have the same name in the certificate as is in the URL you operate against.

Curl considers the server the intended one when the Common Name field or a Subject Alternate Name field in the certificate matches the host name in the URL to which you told Curl to connect.

When the verify value is 1, curl_easy_setopt will return an error and the option value will not be changed. It was previously (in 7.28.0 and earlier) a debug option of some sorts, but it is no longer supported due to frequently leading to programmer mistakes. Future versions will stop returning an error for 1 and just treat 1 and 2 the same.
