### PR TITLE
Supported yamllint rule for xml to yaml convertion.

### DIFF
--- a/libslax/yamlwriter.c
+++ b/libslax/yamlwriter.c
@@ -255,18 +255,72 @@ yamlWriteChildren (slax_writer_t *swp UNUSED, xmlNodePtr parent,
     xmlNodePtr nodep;
     int rc = 0;
 
-    const char *name = yamlName(parent);
-    const char *type = yamlAttribValue(parent, ATT_TYPE);
-    slaxLog("wc: -> [%s] [%s]", name ?: "", type ?: "");
+    struct name_group {
+        const char *name;
+        xmlNodePtr *nodes;
+        int count;
+        int alloc;
+        struct name_group *next;
+    } *groups = NULL, *grp;
 
     for (nodep = parent->children; nodep; nodep = nodep->next) {
-	if (nodep->type != XML_ELEMENT_NODE)
-	    continue;
+        if (nodep->type != XML_ELEMENT_NODE)
+            continue;
+        const char *name = yamlName(nodep);
+        if (!name)
+            continue;
 
-	yamlWriteNode(swp, nodep, flags);
+        for (grp = groups; grp; grp = grp->next)
+            if (strcmp(grp->name, name) == 0)
+                break;
+
+        if (!grp) {
+            grp = calloc(1, sizeof(*grp));
+            grp->name = name;
+            grp->alloc = 4;
+            grp->nodes = calloc(grp->alloc, sizeof(xmlNodePtr));
+            grp->next = groups;
+            groups = grp;
+        } else if (grp->count >= grp->alloc) {
+            grp->alloc *= 2;
+            grp->nodes = realloc(grp->nodes, grp->alloc * sizeof(xmlNodePtr));
+        }
+
+        grp->nodes[grp->count++] = nodep;
     }
 
-    slaxLog("wc: <- [%s] [%s]", name ?: "", type ?: "");
+    for (grp = groups; grp; grp = grp->next) {
+        const char *quote = yamlNameNeedsQuotes(grp->name, flags);
+
+        if (grp->count == 1) {
+            yamlWriteNode(swp, grp->nodes[0], flags);
+        } else {
+            slaxWrite(swp, "%s%s%s:", quote, grp->name, quote);
+            yamlWriteNewline(swp, NEWL_INDENT, flags);
+
+            for (int i = 0; i < grp->count; i++) {
+                const char *val = yamlValue(grp->nodes[i]);
+                slaxWrite(swp, "- ");
+                if (val && !yamlHasChildNodes(grp->nodes[i])) {
+                    slaxWrite(swp, "\"%s\"", val);
+                } else {
+                    yamlWriteChildren(swp, grp->nodes[i], flags);
+                }
+                yamlWriteNewline(swp, 0, flags);
+            }
+
+            slaxWriteIndent(swp, NEWL_OUTDENT);
+        }
+
+        free(grp->nodes);
+    }
+
+    while (groups) {
+        grp = groups;
+        groups = groups->next;
+        free(grp);
+    }
+
     return rc;
 }
 


### PR DESCRIPTION
Supported yamllint rule for xml to yaml convertion.

```
# cat yaml.slax
<?xml version="1.0"?>
<op-script-results xmlns:junos="http://xml.juniper.net/junos/*/junos">
  <data>
    <test n="1234567890">
      <out>Valid line</out>
      <out>Another valid line</out>
    </test>
  </data>
</op-script-results>
root@MS_JET_R1_re:/var/tmp # /usr/libexec/ui/slaxproc -E yaml.slax --xml-to-yaml
---
"data": 
    "test": 
        "out":
            - "Valid line"
            - "Another valid line"
 ```
 
 
 ```
# cat yaml4.slax 
<?xml version="1.0"?>
<data><test n="1.23123123123e+11"><out>        123G</out><out>123 G       </out><out>128000 +         115G + 256000</out><out>128000 + 115 Gcool    + 256000</out></test><test n="56456456"><out>         56M</out><out>56 M        </out><out>128000 +          54M + 256000</out><out>128000 + 54 Mcool     + 256000</out></test><test n="789789"><out>        790k</out><out>790 k       </out><out>128000 +         771K + 256000</out><out>128000 + 771 Kcool    + 256000</out></test><test n="90301"><out>         90k</out><out>90 k        </out><out>128000 +          88K + 256000</out><out>128000 + 88 Kcool     + 256000</out></test><test n="987654321"><out>        988M</out><out>988 M       </out><out>128000 +         942M + 256000</out><out>128000 + 942 Mcool    + 256000</out></test><test n="8760000"><out>        8.8M</out><out>8.8 M       </out><out>128000 +         8.4M + 256000</out><out>128000 + 8 Mcool      + 256000</out></test><out>            </out><out>            </out><out>love:          ab</out><out>more:          ab</out><out>love:        abcd</out><out>more:        abcd</out><out>love:      abcdef</out><out>more:      abcdef</out></data>
root@MS_JET_R1_re:/var/tmp # /usr/libexec/ui/slaxproc -E yaml4.slax --xml-to-yaml
---
"out":
    - "            "
    - "            "
    - "love:          ab"
    - "more:          ab"
    - "love:        abcd"
    - "more:        abcd"
    - "love:      abcdef"
    - "more:      abcdef"
"test":
    - "out":
        - "        123G"
        - "123 G       "
        - "128000 +         115G + 256000"
        - "128000 + 115 Gcool    + 256000"
    
    - "out":
        - "         56M"
        - "56 M        "
        - "128000 +          54M + 256000"
        - "128000 + 54 Mcool     + 256000"
    
    - "out":
        - "        790k"
        - "790 k       "
        - "128000 +         771K + 256000"
        - "128000 + 771 Kcool    + 256000"
    
    - "out":
        - "         90k"
        - "90 k        "
        - "128000 +          88K + 256000"
        - "128000 + 88 Kcool     + 256000"
    
    - "out":
        - "        988M"
        - "988 M       "
        - "128000 +         942M + 256000"
        - "128000 + 942 Mcool    + 256000"
    
    - "out":
        - "        8.8M"
        - "8.8 M       "
        - "128000 +         8.4M + 256000"
        - "128000 + 8 Mcool      + 256000"
 ```