### PR TITLE
Supported jsonlint rule for xml to json conversion.

### DIFF
--- a/libslax/jsonwriter.c
+++ b/libslax/jsonwriter.c
@@ -137,16 +137,14 @@ jsonWriteNewline (slax_writer_t *swp, int delta, unsigned flags)
 }
 
 static int
-jsonWriteNode (slax_writer_t *swp, xmlNodePtr nodep,
-		       unsigned flags)
+jsonWriteNode(slax_writer_t *swp, xmlNodePtr nodep, unsigned flags)
 {
     const char *type = jsonAttribValue(nodep, ATT_TYPE);
     const char *name = jsonName(nodep);
     const char *quote = jsonNameNeedsQuotes(name, flags);
-    const char *comma = jsonNeedsComma(nodep);
 
     if (name == NULL)
-	return 0;
+        return 0;
 
     int nlen = strlen(name) + 1;
     char ename[nlen * 2];
@@ -154,79 +152,138 @@ jsonWriteNode (slax_writer_t *swp, xmlNodePtr nodep,
     name = ename;
 
     if (type) {
-	if (streq(type, VAL_NUMBER) || streq(type, VAL_TRUE)
-	        || streq(type, VAL_FALSE) || streq(type, VAL_NULL)) {
-	    const char *value = jsonValue(nodep);
-	    int vlen = strlen(value) + 1;
-	    char evalue[vlen * 2];
-	    jsonEscape(evalue, sizeof(evalue), value);
-	    value = evalue;
+        if (streq(type, VAL_NUMBER) || streq(type, VAL_TRUE)
+            || streq(type, VAL_FALSE) || streq(type, VAL_NULL)) {
 
-	    if (!(flags & JWF_ARRAY))
-		slaxWrite(swp, "%s%s%s: ", quote, name, quote);
-	    slaxWrite(swp, "%s%s", value, comma);
+            const char *value = jsonValue(nodep);
+            int vlen = strlen(value) + 1;
+            char evalue[vlen * 2];
+            jsonEscape(evalue, sizeof(evalue), value);
+            value = evalue;
 
-	    jsonWriteNewline(swp, 0, flags);
-	    return 0;
+            if (!(flags & JWF_ARRAY))
+                slaxWrite(swp, "%s%s%s: ", quote, name, quote);
 
-	} else if (streq(type, VAL_ARRAY)) {
-	    if (!(flags & JWF_ARRAY))
-		slaxWrite(swp, "%s%s%s: ", quote, name, quote);
-	    slaxWrite(swp, "[");
-	    jsonWriteNewline(swp, NEWL_INDENT, flags);
+            slaxWrite(swp, "%s", value);
+            return 0;
+        } else if (streq(type, VAL_ARRAY)) {
+            if (!(flags & JWF_ARRAY))
+                slaxWrite(swp, "%s%s%s: ", quote, name, quote);
 
-	    jsonWriteChildren(swp, nodep, JWF_ARRAY | flags);
-
-	    slaxWrite(swp, "]%s", comma );
-	    jsonWriteNewline(swp, NEWL_OUTDENT, flags);
-	    return 0;
-
-	} else if (streq(type, VAL_MEMBER)) {
-	    flags |= JWF_ARRAY;
-	    /* fall thru */
-	}
+            slaxWrite(swp, "[");
+            jsonWriteNewline(swp, NEWL_INDENT, flags);
+            jsonWriteChildren(swp, nodep, JWF_ARRAY | flags);
+            slaxWrite(swp, "]");
+            jsonWriteNewline(swp, NEWL_OUTDENT, flags);
+            return 0;
+        } else if (streq(type, VAL_MEMBER)) {
+            flags |= JWF_ARRAY;
+            // fall through
+        }
     }
 
+    // Object with children
     if (jsonHasChildNodes(nodep)) {
-	if (!(flags & JWF_ARRAY))
-	    slaxWrite(swp, "%s%s%s: ", quote, name, quote);
-	slaxWrite(swp, "{");
-	jsonWriteNewline(swp, NEWL_INDENT, flags);
+        if (!(flags & JWF_ARRAY))
+            slaxWrite(swp, "%s%s%s: ", quote, name, quote);
 
-	jsonWriteChildren(swp, nodep, flags & ~JWF_ARRAY);
+        slaxWrite(swp, "{");
+        jsonWriteNewline(swp, NEWL_INDENT, flags);
 
-	slaxWrite(swp, "}%s", comma);
-	jsonWriteNewline(swp, NEWL_OUTDENT, flags);
+        jsonWriteChildren(swp, nodep, flags & ~JWF_ARRAY);
 
+        slaxWrite(swp, "}");
+        jsonWriteNewline(swp, NEWL_OUTDENT, flags);
     } else {
-	const char *value = jsonValue(nodep);
-	int vlen = value ? strlen(value) + 1 : 0;
-	char evalue[vlen * 2 + 1];
-	if (value) {
-	    jsonEscape(evalue, sizeof(evalue), value);
-	    value = evalue;
-	}
+        // Leaf node
+        const char *value = jsonValue(nodep);
+        int vlen = value ? strlen(value) + 1 : 0;
+        char evalue[vlen * 2 + 1];
 
-	if (!(flags & JWF_ARRAY))
-	    slaxWrite(swp, "%s%s%s: ", quote, name, quote);
+        if (value)
+            jsonEscape(evalue, sizeof(evalue), value);
+        else
+            evalue[0] = '\0';
 
-	slaxWrite(swp, "\"%s\"%s", value ?: "", comma);
-	jsonWriteNewline(swp, 0, flags);
+        if (!(flags & JWF_ARRAY))
+            slaxWrite(swp, "%s%s%s: ", quote, name, quote);
+
+        slaxWrite(swp, "\"%s\"", value ? evalue : "");
     }
 
     return 0;
 }
 
 static int
-jsonWriteChildren (slax_writer_t *swp UNUSED, xmlNodePtr parent,
-		   unsigned flags)
+jsonWriteChildren(slax_writer_t *swp, xmlNodePtr parent, unsigned flags)
 {
     xmlNodePtr nodep;
     int rc = 0;
 
+    struct node_group {
+        const char *name;
+        xmlNodePtr nodes[256];
+        int count;
+    };
+
+    struct node_group groups[256];
+    int group_count = 0;
+
+    // Group children by name
     for (nodep = parent->children; nodep; nodep = nodep->next) {
-	if (nodep->type == XML_ELEMENT_NODE)
-	    jsonWriteNode(swp, nodep, flags);
+        if (nodep->type != XML_ELEMENT_NODE)
+            continue;
+
+        const char *name = jsonName(nodep);
+        int i, found = 0;
+
+        for (i = 0; i < group_count; i++) {
+            if (strcmp(groups[i].name, name) == 0) {
+                groups[i].nodes[groups[i].count++] = nodep;
+                found = 1;
+                break;
+            }
+        }
+
+        if (!found && group_count < 256) {
+            groups[group_count].name = name;
+            groups[group_count].nodes[0] = nodep;
+            groups[group_count].count = 1;
+            group_count++;
+        }
+    }
+
+    for (int i = 0; i < group_count; i++) {
+        struct node_group *grp = &groups[i];
+        const char *quote = jsonNameNeedsQuotes(grp->name, flags);
+
+        if (grp->count == 1) {
+            // Single node
+            jsonWriteNode(swp, grp->nodes[0], flags);
+        } else {
+            // Multiple nodes
+            slaxWrite(swp, "%s%s%s: [", quote, grp->name, quote);
+            jsonWriteNewline(swp, NEWL_INDENT, flags);
+
+            for (int j = 0; j < grp->count; j++) {
+                jsonWriteNode(swp, grp->nodes[j], flags | JWF_ARRAY);
+
+                if (j != grp->count - 1) {
+                    slaxWrite(swp, ",");
+		    slaxWrite(swp, " ");
+		}
+                jsonWriteNewline(swp, 0, flags);
+            }
+
+            slaxWrite(swp, "]");
+            if (i != group_count - 1)
+                slaxWrite(swp, ",");
+            jsonWriteNewline(swp, NEWL_OUTDENT, flags);
+        }
+
+        // Add comma+newline between top-level entries (if not inside array)
+        if (grp->count == 1 && i != group_count - 1)
+            slaxWrite(swp, ",\n");
     }
 
     return rc;


### PR DESCRIPTION
Examples

```
# /usr/libexec/ui/slaxproc -E json_test2.slax
<?xml version="1.0"?>
<data><test n="1.23123123123e+11"><out>        123G</out><out>123 G       </out><out>128000 +         115G + 256000</out><out>128000 + 115 Gcool    + 256000</out></test><test n="56456456"><out>         56M</out><out>56 M        </out><out>128000 +          54M + 256000</out><out>128000 + 54 Mcool     + 256000</out></test><test n="789789"><out>        790k</out><out>790 k       </out><out>128000 +         771K + 256000</out><out>128000 + 771 Kcool    + 256000</out></test><test n="90301"><out>         90k</out><out>90 k        </out><out>128000 +          88K + 256000</out><out>128000 + 88 Kcool     + 256000</out></test><test n="987654321"><out>        988M</out><out>988 M       </out><out>128000 +         942M + 256000</out><out>128000 + 942 Mcool    + 256000</out></test><test n="8760000"><out>        8.8M</out><out>8.8 M       </out><out>128000 +         8.4M + 256000</out><out>128000 + 8 Mcool      + 256000</out></test><out>            </out><out>            </out><out>love:          ab</out><out>more:          ab</out><out>love:        abcd</out><out>more:        abcd</out><out>love:      abcdef</out><out>more:      abcdef</out></data>
 # /usr/libexec/ui/slaxproc -E json_test2.slax --json
{ "test": [ { "out": [ "        123G",  "123 G       ",  "128000 +         115G + 256000",  "128000 + 115 Gcool    + 256000" ] } ,  { "out": [ "         56M",  "56 M        ",  "128000 +          54M + 256000",  "128000 + 54 Mcool     + 256000" ] } ,  { "out": [ "        790k",  "790 k       ",  "128000 +         771K + 256000",  "128000 + 771 Kcool    + 256000" ] } ,  { "out": [ "         90k",  "90 k        ",  "128000 +          88K + 256000",  "128000 + 88 Kcool     + 256000" ] } ,  { "out": [ "        988M",  "988 M       ",  "128000 +         942M + 256000",  "128000 + 942 Mcool    + 256000" ] } ,  { "out": [ "        8.8M",  "8.8 M       ",  "128000 +         8.4M + 256000",  "128000 + 8 Mcool      + 256000" ] }  ], "out": [ "            ",  "            ",  "love:          ab",  "more:          ab",  "love:        abcd",  "more:        abcd",  "love:      abcdef",  "more:      abcdef" ] }
```

```
# /usr/libexec/ui/slaxproc -E json_file.slax 
<?xml version="1.0" standalone="yes"?>
<op-script-results xmlns:junos="http://xml.juniper.net/junos/*/junos" xmlns:xnm="http://xml.juniper.net/xnm/1.1/xnm" xmlns:jcs="http://xml.juniper.net/junos/commit-scripts/1.0">
  <device>
    <hostname>router-01</hostname>
    <uptime>5 days</uptime>
    <interfaces>
      <interface>
        <name>ge-0/0/0</name>
        <status>up</status>
      </interface>
      <interface>
        <name>ge-0/0/1</name>
        <status>down</status>
      </interface>
    </interfaces>
  </device>
</op-script-results>
# /usr/libexec/ui/slaxproc -E json_file.slax --json
{ "device": { "hostname": "router-01",
"uptime": "5 days",
"interfaces": { "interface": [ { "name": "ge-0/0/0",
"status": "up"} ,  { "name": "ge-0/0/1",
"status": "down"}  ] } } }
```
