### PR TITLE
Handle json convertion incase of invalid xml

### DIFF
--- a/libslax/jsonwriter.c
+++ b/libslax/jsonwriter.c
@@ -259,5 +259,9 @@ slaxJsonWriteDoc (slaxWriterFunc_t func, void *data, xmlDocPtr docp,
 		      unsigned flags)
 {
     xmlNodePtr nodep = xmlDocGetRootElement(docp);
+    if (nodep == NULL) {
+        slaxLog("%s","Error: XML document has no root element.");
+        return -1;
+    }
     return slaxJsonWriteNode(func, data, nodep, flags | JWF_ROOT);
 }


### PR DESCRIPTION
Handle core scenario in case of converting invalid xml data.

```
cat val.slax
version 1.3;

main {
    var $input = 75;

    var $result := {
        <result> {
            if ($input >= 50) {
                <status> "pass";
                <score> $input;
            }

            if ($input < 50) {
                <status> "fail";
                <score> $input;
            }
        }
    }

    expr $result;
}

/usr/libexec/ui/slaxproc -E val.slax --json
Segmentation fault (core dumped)

```

After fix:

```
root@MS_JET_R1_re:/var/db/scripts/op # /usr/libexec/ui/slaxproc -v -E core.slax --json
getopt: rc 69/45 optind 3, opt_number -1, arg '(null)'
getopt: rc 0/00 optind 5, opt_number 24, arg '(null)'
Error: XML document has no root element.
```